### PR TITLE
create window based on current server time and maximum overlap of sampling period to query historical metrics

### DIFF
--- a/vsphere/datadog_checks/vsphere/metrics.py
+++ b/vsphere/datadog_checks/vsphere/metrics.py
@@ -68,8 +68,8 @@ HOST_METRICS = {
 
 # All metrics that can be collected from Datastores.
 DATASTORE_METRICS = {
-#     'datastore.numberReadAveraged.average' : "*",
-#     'datastore.numberWriteAveraged.average' : "*",
+    'datastore.numberReadAveraged.average' : None,
+    'datastore.numberWriteAveraged.average' : None,
     'disk.capacity.latest' : None,
     'disk.provisioned.latest' : None,
     'disk.used.latest' : None,

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -38,6 +38,8 @@ except ImportError:
 
 # Default vCenter sampling interval
 REAL_TIME_INTERVAL = 20
+#https://www.vmware.com/support/developer/converter-sdk/conv61_apireference/vim.HistoricalInterval.html
+HISTORICAL_TIME_INTERVAL = 300
 # Metrics are only collected on vSphere VMs marked by custom field value
 VM_MONITORING_FLAG = 'DatadogMonitored'
 # The size of the ThreadPool used to process the request queue
@@ -1239,7 +1241,9 @@ class VSphereCheck(AgentCheck):
                     else:
                         # We cannot use `maxSample` for historical metrics, let's specify a timewindow that will
                         # contain at least one element
-                        query_spec.startTime = datetime.now() - timedelta(hours=2)
+                        # Use the default sampling period for historical resources
+                        query_spec.intervalId = HISTORICAL_TIME_INTERVAL
+                        query_spec.startTime = datetime.now() - timedelta(seconds=HISTORICAL_TIME_INTERVAL)
 
                     query_specs.append(query_spec)
                 if query_specs:

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -1210,6 +1210,7 @@ class VSphereCheck(AgentCheck):
         if i_key not in self.morlist:
             self.log.info(u"Not collecting metrics for this instance, nothing to do yet: {0}".format(i_key))
             return
+        server_instance = self._get_server_instance(instance)
 
         for resource_type in ALL_RESOURCES_WITH_METRICS:
             # Safeguard, let's avoid collecting multiple resource types in the same call
@@ -1243,7 +1244,7 @@ class VSphereCheck(AgentCheck):
                         # contain at least one element
                         # Use the default sampling period for historical resources
                         query_spec.intervalId = HISTORICAL_TIME_INTERVAL
-                        query_spec.startTime = datetime.now() - timedelta(seconds=HISTORICAL_TIME_INTERVAL)
+                        query_spec.startTime = server_instance.CurrentTime() - timedelta(seconds=HISTORICAL_TIME_INTERVAL)
 
                     query_specs.append(query_spec)
                 if query_specs:

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -1321,7 +1321,7 @@ class VSphereCheck(AgentCheck):
 
         # Second part: do the job
         self.collect_metrics(instance)
-        self._query_event(instance)
+        #self._query_event(instance)
 
         # For our own sanity
         self._clean()


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?
https://jira.nutanix.com/browse/ENG-312352

A brief description of the change being made with this pull request.

### Motivation
Use default historical interval for query of datastore metrics

What inspired you to submit this pull request?
https://jira.nutanix.com/browse/ENG-312352
