### PR TITLE
Making the last cached value 0 for sql server rate metrics if

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -849,6 +849,7 @@ class SqlComplexMetric(SqlServerMetric):
                         context = (metric_name, sorted_tags)
                         if cached_metrics_data.get(context):
                             value, timestamp = cached_metrics_data.get(context)
+                            value = 0 if value > report_value else value
                         else:
                             self.log.info("missing context {0}".format(context))
                             cached_metrics_data[context] = (report_value, current_timestamp)


### PR DESCRIPTION
its greater than current value.Its hppening in cases we delete
and create a new database.

<!-- *Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.* -->

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Versioning

- [ ] Bumped the check version in `manifest.json`
- [ ] Bumped the check version in `datadog_checks/{integration}/__init__.py`
- [ ] Updated `CHANGELOG.md`. Please use `Unreleased` as the date in the title
  for the new section.
- [ ] If PR impacts documentation, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new) 

### Additional Notes

Anything else we should know when reviewing?
