### PR TITLE
vcenter scale parameters , cluster metrics

### DIFF
--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -43,7 +43,7 @@ HISTORICAL_TIME_INTERVAL = 1800
 # Metrics are only collected on vSphere VMs marked by custom field value
 VM_MONITORING_FLAG = 'DatadogMonitored'
 # The size of the ThreadPool used to process the request queue
-DEFAULT_SIZE_POOL = 4
+DEFAULT_SIZE_POOL = 10
 # The interval in seconds between two refresh of the entities list
 REFRESH_MORLIST_INTERVAL = 3 * 60
 # The interval in seconds between two refresh of metrics metadata (id<->name)
@@ -53,7 +53,7 @@ REFRESH_METRICS_METADATA_INTERVAL = 10 * 60
 # is significantly lower than the size of the queryPerf response, so allow specifying a different value.
 BATCH_COLLECTOR_SIZE = 500
 
-DEFAULT_METRICS_PER_QUERY = 500
+DEFAULT_METRICS_PER_QUERY = 5000
 DEFAULT_MAX_QUERY_METRICS = 64
 # the vcenter maxquerymetrics option
 MAX_QUERY_METRICS_OPTION = "config.vpxd.stats.maxQueryMetrics"

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -48,8 +48,7 @@ DEFAULT_SIZE_POOL = 4
 REFRESH_MORLIST_INTERVAL = 3 * 60
 # The interval in seconds between two refresh of metrics metadata (id<->name)
 REFRESH_METRICS_METADATA_INTERVAL = 10 * 60
-# The amount of jobs batched at the same time in the queue to query available metrics
-BATCH_MORLIST_SIZE = 50
+
 # Maximum number of objects to collect at once by the propertyCollector. The size of the response returned by the query
 # is significantly lower than the size of the queryPerf response, so allow specifying a different value.
 BATCH_COLLECTOR_SIZE = 500
@@ -117,9 +116,6 @@ class VSphereCheck(AgentCheck):
         self.event_config = {}
         # Batch size for property collector
         self.batch_collector_size = init_config.get("batch_property_collector_size", BATCH_COLLECTOR_SIZE)
-
-        # Batch size for query available metrics
-        self.batch_morlist_size = init_config.get('batch_morlist_size', BATCH_MORLIST_SIZE)
 
         # Metrics Query size
         self.max_historical_metrics = init_config.get("max_historical_metrics", DEFAULT_MAX_QUERY_METRICS)

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -535,12 +535,13 @@ class VSphereCheck(AgentCheck):
 
         return monitor_clusters
 
-    def createPropertyOptions(self):
-            retr_opts = vmodl.query.PropertyCollector.RetrieveOptions()
-            # To limit the number of objects retrieved per call.
-            # If batch_collector_size is 0, collect maximum number of objects.
-            retr_opts.maxObjects = self.batch_collector_size or None
-            return retr_opts
+    def createPropertyOptions(self,max_object_count = None):
+        retr_opts = vmodl.query.PropertyCollector.RetrieveOptions()
+        # To limit the number of objects retrieved per call.
+        # If batch_collector_size is 0, collect maximum number of objects.
+        if max_object_count is not None:
+            retr_opts.maxObjects = max_object_count
+        return retr_opts
 
     def _discover_mor(self, instance, tags, regexes=None, include_only_marked=False):
         """


### PR DESCRIPTION
### What does this PR do?

A brief description of the change being made with this pull request.
1. Use property collector's throttling mechanism to obtain maximum no of objects in a single
property query call (https://www.vmware.com/support/developer/converter-sdk/conv61_apireference/vmodl.query.PropertyCollector.RetrieveOptions.html)
2. increase the concurrency levels (shared across multiple vcenter instances) 
3. increase the maximum batch size to query realtime metrics for vms and hosts applicable for each vcenter instance
4. https://jira.nutanix.com/browse/ENG-322492 (use 2 hrs as time window to fetch cluster metrics)

### Motivation
large vcenter monitoring 

### Testing Guidelines
test for large monitoring data sets 

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
